### PR TITLE
fix: bug for depth image extract

### DIFF
--- a/exploreMaterial-tool/accessDMDAnn.py
+++ b/exploreMaterial-tool/accessDMDAnn.py
@@ -400,13 +400,13 @@ class exportClass():
     def depthFrameIntervalToImages(self, frameStart, frameEnd, mosaicFrameStart, depthVideoArray, capVideo, name):
         frameCount = mosaicFrameStart
         for i in range(frameStart,frameEnd+1):
-            if i != self.frameNum:
+            if i < self.frameNum:
                 cv2.imwrite(name+"_"+str(frameCount)+".tif",depthVideoArray[i])
             else:
                 #write a black image
                 if self.size != "original":
                     cv2.imwrite(name+"_"+str(frameCount)+".tif",np.zeros((self.size[1],self.size[0]),dtype=np.uint16))
-                cv2.imwrite(name+"_"+str(frameCount)+".tif",np.zeros(int((capVideo.get(cv2.CAP_PROP_FRAME_HEIGHT)),
+                cv2.imwrite(name+"_"+str(frameCount)+".tif",np.zeros((int(capVideo.get(cv2.CAP_PROP_FRAME_HEIGHT)),
                                                                          int(capVideo.get(cv2.CAP_PROP_FRAME_WIDTH))),dtype=np.uint16))
             frameCount +=1
 


### PR DESCRIPTION
Two bugs came up when I extracted the depth map.

1. Boundary value bug, because `frameEnd` may be greater than `self.frameNum`.
2. I guess it should be a clerical mistake in line 409.
